### PR TITLE
Copy Repeater action enhancements, link to module config in notice

### DIFF
--- a/ProcessAdminActions.module
+++ b/ProcessAdminActions.module
@@ -324,7 +324,8 @@ class ProcessAdminActions extends Process implements Module, ConfigurableModule 
             $this->getActions($customActionsDir, false);
         }
 
-        if($this->newActionsAvailable()) $this->wire()->warning("There are new actions available - please visit the module config settings to adjust approved roles and menu status.");
+        $moduleConfigUrl = $this->config->urls->admin . 'module/edit?name=' . $this->className;
+        if($this->newActionsAvailable()) $this->wire()->warning("There are new actions available - please visit the <a href='$moduleConfigUrl'>module config settings</a> to adjust approved roles and menu status.", Notice::allowMarkup);
 
         if(isset($this->data['site'])) ksort($this->data['site']);
         ksort($this->data['core']);


### PR DESCRIPTION
Added support for Repeater Matrix to CopyRepeaterItemsToOtherPage
action. Also added to this action are failure conditions for if the
repeater field does not exist on the source or destination pages, and
files/images are now copied to cloned repeater items.

Added a link to the module config inside the notice advising that there
are new actions available.