### PR TITLE
Rename execute step to prevent firewall blocking

### DIFF
--- a/ProcessAdminActions.module.php
+++ b/ProcessAdminActions.module.php
@@ -196,10 +196,10 @@ class ProcessAdminActions extends Process implements Module, ConfigurableModule 
     }
 
     /**
-     * Executed when ./execute/ url for module is accessed
+     * Executed when ./run/ url for module is accessed
      *
      */
-    public function ___executeExecute() {
+    public function ___executeRun() {
 
         set_time_limit(0);
 
@@ -434,7 +434,7 @@ class ProcessAdminActions extends Process implements Module, ConfigurableModule 
         $form = $this->wire('modules')->get("InputfieldForm");
         $form->name = 'options';
         $form->method = 'post';
-        $form->action = './execute?action='.$this->action;
+        $form->action = './run?action='.$this->action;
 
         $f = $this->wire('modules')->get("InputfieldMarkup");
         $f->name = 'details';

--- a/ProcessAdminActions.module.php
+++ b/ProcessAdminActions.module.php
@@ -280,6 +280,17 @@ class ProcessAdminActions extends Process implements Module, ConfigurableModule 
 
     }
 
+    /**
+     * Executed when legacy ./execute/ url for module is accessed
+     *
+     */
+    public function ___executeExecute() {
+
+        // "execute" is not in use anymore: renamed to "run" to prevent firewall blocking
+        // we'll pass through calls to the new method for legacy installs with possibly hardcoded urls
+        return $this->___executeRun();
+
+    }
 
     /**
      * Build the Select form

--- a/README.md
+++ b/README.md
@@ -193,9 +193,9 @@ http://mysite.dev/processwire/setup/admin-actions/options?action=TemplateFieldsB
 ```
 or you can execute immediately:
 ```
-http://mysite.dev/processwire/setup/admin-actions/execute?action=TemplateFieldsBatcher&templates=29|56&fields=219&addOrRemove=add
+http://mysite.dev/processwire/setup/admin-actions/run?action=TemplateFieldsBatcher&templates=29|56&fields=219&addOrRemove=add
 ```
-Note the "options" vs "execute" as the last path segment before the parameters.
+Note the "options" vs "run" as the last path segment before the parameters.
 
 ### Calling an action via the API
 


### PR DESCRIPTION
- Rename "execute" step to "run"
- Add redirect for hard-coded legacy urls